### PR TITLE
Improve regexes implementation and reporting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 Crude and quick implementation of a tool to run `grep` recursively through
 archives.
 
-An extension (or fork, or variant) of https://github.com/sarpt/avfsgrep
+A successor of https://github.com/sarpt/avfsgrep, which used `avfs` as a quick
+way to solve archive-handling business-logic. With `libarchive` usable with FFI
+in `deno` there's no need to use `avfsgrep` anymore (if anything, issues with
+FUSE in docker images make `argrep` way easier to use than `avfsgrep` which is
+dependent on `avfs` FUSE-based implementation).
 
 ### execution example
 
@@ -56,16 +60,19 @@ provided/hardcoded in the Dockerfile and there's no need to provide them again.
 
 ### arguments
 
-- `-i, --i` : input file (ignored when unnamed arguments before `--` provided)
-- `-r, --r` : regex for `grep` and its variants
-- `--pr` : (list) path regexes
-- `--fr` : (list) filename regexes
-- `-v` : verbose logging
-- `--er` : (list) extension regexes
+- `-r, --r` : regex for `grep` and its variants. It's mandatory to provide it.
+- `-i, --i` : input file. Mandatory, unless unnamed arguments before `--`
+  provided. Ignored when unnamed arguments before `--` provided.
+- `--pr` : (list) path regexes. Accepts JS regexp patterns.
+- `--fr` : (list) filename regexes. Accepts JS regexp patterns.
+- `-v` : verbose logging. `false` by default.
+- `--ignore-invalid-regex` : do not exit when invalid regex pattern encountered.
+  Invalid regexes are ignored, but correct ones are tested. `false` by default.
+- `--er` : (list) extension regexes. Accepts JS regexp patterns.
 - `--libarchive`: path to libarchive library. When not provided,
-  `/usr/lib/libarchive.so` is used by default
+  `/usr/lib/libarchive.so` is used by default.
 - `--libmagic`: path to libmagic library. When not provided,
-  `/usr/lib/libmagic.so` is used by default
+  `/usr/lib/libmagic.so` is used by default.
 
 ### unnamed arguments
 

--- a/regexes.ts
+++ b/regexes.ts
@@ -1,16 +1,18 @@
 import { basename, extname } from "https://deno.land/std@0.120.0/path/mod.ts";
 
 type regexes = {
-  path?: string[];
-  fileName?: string[];
-  extension?: string[];
+  path?: RegExp[];
+  fileName?: RegExp[];
+  extension?: RegExp[];
 };
 
 export function unmatchedByRegexes(path: string, regexes?: regexes): boolean {
   const pathRegexes = regexes && regexes.path ? regexes.path : [];
   if (
     pathRegexes.length > 0 &&
-    !pathRegexes.some((pathRegex) => path.includes(pathRegex))
+    !pathRegexes.some((pathRegex) => {
+      return pathRegex.test(path);
+    })
   ) {
     return true;
   }
@@ -18,9 +20,9 @@ export function unmatchedByRegexes(path: string, regexes?: regexes): boolean {
   const fileNameRegexes = regexes && regexes.fileName ? regexes.fileName : [];
   if (
     fileNameRegexes.length > 0 &&
-    !fileNameRegexes.some((fileNameRegex) =>
-      basename(path).includes(fileNameRegex)
-    )
+    !fileNameRegexes.some((fileNameRegex) => {
+      return fileNameRegex.test(basename(path));
+    })
   ) {
     return true;
   }
@@ -30,12 +32,32 @@ export function unmatchedByRegexes(path: string, regexes?: regexes): boolean {
     : [];
   if (
     extensionRegexes.length > 0 &&
-    !extensionRegexes.some((fileNameRegex) =>
-      extname(path).includes(fileNameRegex)
-    )
+    !extensionRegexes.some((extensionRegex) => {
+      return extensionRegex.test(extname(path));
+    })
   ) {
     return true;
   }
 
   return false;
+}
+
+export function patternsToRegexes(
+  patterns: string[],
+): { regexes: RegExp[]; errMsgs: string[] } {
+  const errMsgs: string[] = [];
+  const regexes: RegExp[] = [];
+
+  patterns.forEach((pattern) => {
+    try {
+      const regex = new RegExp(pattern);
+      regexes.push(regex);
+    } catch (err) {
+      errMsgs.push(
+        `couldn't construct regexp from pattern "${pattern}": ${err}`,
+      );
+    }
+  });
+
+  return { regexes, errMsgs };
 }


### PR DESCRIPTION
Due to "proof of concept" nature of earlier commits, path/filename/extension regexes weren't as mush regexes as just queries/phrases checked with `includes` on them. This commit implements proper RegExp's with additional behavior handling and reporting.